### PR TITLE
Add configurable formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,16 @@
+name: ci
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,8 +409,15 @@ pub trait Formatter: Clone {
 }
 
 /// Formats JSON as compactly as possible.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct CompactFormatter {}
+
+impl CompactFormatter {
+	/// Creates a new compact JSON formatter.
+	pub const fn new() -> Self {
+		Self {}
+	}
+}
 
 impl Formatter for CompactFormatter {}
 
@@ -423,22 +430,22 @@ pub struct PrettyFormatter<'a> {
 
 impl Default for PrettyFormatter<'_> {
 	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl PrettyFormatter<'_> {
+	/// Creates a new human-readable formatter with two spaces for indentation.
+	pub const fn new() -> Self {
 		// Same default as serde_json::ser::PrettyFormatter
 		Self {
 			indent: "  ",
 			depth: 0,
 		}
 	}
-}
-
-impl PrettyFormatter<'_> {
-	/// Creates a new human-readable formatter with two spaces for indentation.
-	pub fn new() -> Self {
-		Self::default()
-	}
 
 	/// Creates a new formatter using `indent` for indentation.
-	pub fn with_indent<'a>(indent: &'a str) -> PrettyFormatter<'a> {
+	pub const fn with_indent<'a>(indent: &'a str) -> PrettyFormatter<'a> {
 		PrettyFormatter {
 			indent,
 			depth: 0,


### PR DESCRIPTION
Thank you for writing this crate. One thing I missed from `serde_json` was the ability to control whitespace, this PR does the following:
- Added configurable formatting, based on [`serde_json::ser::Formatter`](https://docs.rs/serde_json/latest/serde_json/ser/trait.Formatter.html), but most existing usage should be unaffected
- Added basic GitHub CI workflow to build and run tests