### PR TITLE
Add cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,29 @@
+[advisories]
+version = 2
+yanked = "warn"
+
+[bans]
+multiple-versions = "allow"
+wildcards = "deny"
+# private package can use wildcard paths such as `package.workspace = true`
+allow-wildcard-paths = true
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[licenses]
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.93
+# (extending this list is only allowed after agreement by TD management)
+allow = ["Apache-2.0", "MIT", "Unlicense"]
+
+# ignore the local workspace crates
+[licenses.private]
+ignore = true 


### PR DESCRIPTION
Cargo deny is a nice multipurpose tool for checking security issues with dependencies and denying various things from duplicate versions of dependencies to specific packages etc.