### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/zotta/json-writer-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 itoa = "1.0.6"
 ryu = "1.0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 description = "Simple and fast crate for writing JSON to a string without creating intermediate objects"
 license = "Unlicense"
-categories = [ "encoding" ]
+categories = [ "encoding", "no-std" ]
 repository = "https://github.com/zotta/json-writer-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -5,3 +5,14 @@
 [![Current Crates.io Version](https://img.shields.io/crates/v/json-writer.svg)](https://crates.io/crates/json-writer)
 
 Simple and fast JSON writer for Rust.
+
+## No-std support
+
+In no_std mode, almost all of the same API is available and works the same way.
+To depend on json-writer in no_std mode, disable our default enabled "std" feature in
+Cargo.toml.
+
+```toml
+[dependencies]
+json-writer = { version = "0.3", default-features = false }
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![warn(missing_docs)]
-#![no_std]
-
 //!
 //! Simple and fast crate for writing JSON to a string without creating intermediate objects.
 //!
@@ -133,6 +130,14 @@
 //! [dependencies]
 //! json-writer = { version = "0.3", default-features = false }
 //! ```
+#![warn(missing_docs)]
+#![no_std]
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
 
 ///
 /// Helper for appending a JSON object to the borrowed buffer.
@@ -347,6 +352,7 @@ impl JSONObjectWriter<'_, String> {
     /// Writes the entire buffer to given writer and clears entire buffer on success.
     ///
     #[inline(always)]
+    #[cfg(feature = "std")]
     pub fn output_buffered_data<Writer: std::io::Write>(
         &mut self,
         writer: &mut Writer,
@@ -936,6 +942,7 @@ fn write_part_of_string_impl(output_buffer: &mut String, input: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{borrow::ToOwned, string::ToString, vec};
 
     #[test]
     fn test_array() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![no_std]
 
 //!
 //! Simple and fast crate for writing JSON to a string without creating intermediate objects.
@@ -122,6 +123,16 @@
 //! assert_eq!(&object_str, "{\"number\":42,\"number\":43}");
 //! ```
 //!
+//! ## No-std support
+//!
+//! In no_std mode, almost all of the same API is available and works the same way.
+//! To depend on json-writer in no_std mode, disable our default enabled "std" feature in
+//! Cargo.toml.
+//!
+//! ```toml
+//! [dependencies]
+//! json-writer = { version = "0.3", default-features = false }
+//! ```
 
 ///
 /// Helper for appending a JSON object to the borrowed buffer.


### PR DESCRIPTION
json-writer is designed to work without an allocator and so can easily be made [`no_std`](https://docs.rust-embedded.org/book/intro/no-std.html) compatible.